### PR TITLE
Validation of hex string on `rawTx` object value

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -143,7 +143,7 @@ export class ArcClient {
       }
 
       txs.forEach((tx) => {
-        if (!/^[0-9A-Fa-f]+$/.test(tx)) {
+        if (!/^[0-9A-Fa-f]+$/.test(tx["rawTx"])) {
           throw new Error("tx must be a valid hex string");
         }
       });


### PR DESCRIPTION
Currently if `js-arc-clinet` is used for posting multiple transactions with `application/json` format, there is validation for hex string on the whole transaction object instead of the value of that transaction