### PR TITLE
fix require example on Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ const result = await arcClient.getTransactionStatus(txid);
 or as commonjs module:
 
 ```javascript
-const { ArcClient } = require('js-arc-client').ArcClient;
+const { ArcClient } = require('js-arc-client');
 
 const arcClient = new ArcClient('https://api.taal.com/arc', {
   authorization: '<api-key>'


### PR DESCRIPTION
The current example on Readme leads to error 'not a constructor'